### PR TITLE
Fix heading specificity issue with `:is()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ritterim/skellycss",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ritterim/skellycss",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A light-weight CSS framework to quickly implement skeletons into your projects.",
   "main": "dist/skelly.js",
   "files": [

--- a/src/style.scss
+++ b/src/style.scss
@@ -140,12 +140,7 @@ p {
   }
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+.skeleton:is(h1, h2, h3, h4, h5, h6) {
   margin: 0;
   padding: 0;
   .skeleton__line {


### PR DESCRIPTION
No Issue

Updates:
- Wrap heading tags in `.skeleton:is()` to be scope specificity to skelly